### PR TITLE
move to defaults and add sudo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,3 @@
 makepkg_nonroot_user: "{{ ansible_ssh_user | default(ansible_user) }}"
+packer_dependencies:
+    - jshon

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: coxley.packer | install deps
   pacman: name={{ item }} state=latest
-  with_items:
-    - jshon
+  with_items: "{{ packer_dependencies }}"
+  sudo: yes
 
 - name: coxley.packer | install packer
   include: aur/pkg.yml pkg_name=packer-git


### PR DESCRIPTION
I moved the `makepkg_nonroot_user` to the defaults folder so that it can be overwritten. I also added a `packer_dependencies` variable because I wanted to install `python2-httplib2`. 

Since the `aur/pkg.yml` makes heavy use of `sudo` I think it makes sense to specify `sudo` when installing the dependencies with pacman.
